### PR TITLE
Add support for running subprocesses at lower priority

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,6 +18,7 @@ import (
 )
 
 const (
+	ARG_LOW_PRIORITY    = "low-priority"
 	ARG_OUTPUT          = "output"
 	ARG_PLEX            = "plex"
 	ARG_PLEX_EPISODE    = "plex-episode"
@@ -90,8 +91,9 @@ media library a bit easier.`,
 
 		// Setup the transcoding task
 		pipe.Transcode = &tasks.TranscodeVideo{
-			Logger:  logger,
-			WorkDir: tempDir,
+			Logger:           logger,
+			UseLowerPriority: viper.GetBool(ARG_LOW_PRIORITY),
+			WorkDir:          tempDir,
 		}
 		if err := loadTemplates(pipe.Transcode); err != nil {
 			logger.Errorw("error while loading templates", "err", err)
@@ -120,6 +122,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	viper.SetEnvKeyReplacer(strings.NewReplacer("-", "_"))
 
+	rootCmd.Flags().Bool(ARG_LOW_PRIORITY, false, "Runs subprocesses (ffmpeg/mkvmerge/etc) at a lower process priority")
 	rootCmd.Flags().String(ARG_OUTPUT, "robin-output", "Specifies a folder to copy final output to")
 	rootCmd.Flags().Bool(ARG_PLEX, false, "Enables renaming of output to plex recommendations")
 	rootCmd.Flags().Int(ARG_PLEX_EPISODE, 1, "Starting episode number for plex tv shows")

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.13.0
 	go.uber.org/zap v1.23.0
+	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a
 	gopkg.in/yaml.v3 v3.0.1
 )
 
@@ -26,7 +27,6 @@ require (
 	github.com/subosito/gotenv v1.4.1 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
-	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/pkg/ffmpeg/ffmpeg.go
+++ b/pkg/ffmpeg/ffmpeg.go
@@ -4,10 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"golang.org/x/sys/windows"
-	"os"
 	"os/exec"
-	"runtime"
 	"strings"
 )
 
@@ -23,26 +20,6 @@ func filter(ss []string, test func(string) bool) []string {
 		}
 	}
 	return r
-}
-
-func setLowerPriority(p *os.Process) error {
-	switch runtime.GOOS {
-	case "windows":
-		// Acquire a handle to the child process
-		// PROCESS_SET_INFORMATION is the access level needed when calling SetPriorityClass
-		// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setpriorityclass
-		h, err := windows.OpenProcess(windows.PROCESS_SET_INFORMATION, false, uint32(p.Pid))
-		if err != nil {
-			return err
-		}
-
-		// Attempt to modify the priority class of the child process
-		return windows.SetPriorityClass(h, windows.BELOW_NORMAL_PRIORITY_CLASS)
-	case "linux":
-		// TODO: Fill this out when we have a linux machine to test on
-	}
-
-	return nil
 }
 
 type Runner struct {

--- a/pkg/ffmpeg/priority.go
+++ b/pkg/ffmpeg/priority.go
@@ -1,0 +1,11 @@
+//go:build !windows
+
+package ffmpeg
+
+import "os"
+
+func setLowerPriority(p *os.Process) error {
+	// TODO: Fill this out when we have a linux machine to test on
+	// For now, just be a no-op
+	return nil
+}

--- a/pkg/ffmpeg/priority_windows.go
+++ b/pkg/ffmpeg/priority_windows.go
@@ -1,0 +1,19 @@
+package ffmpeg
+
+import (
+	"golang.org/x/sys/windows"
+	"os"
+)
+
+func setLowerPriority(p *os.Process) error {
+	// Acquire a handle to the child process
+	// PROCESS_SET_INFORMATION is the access level needed when calling SetPriorityClass
+	// https://learn.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-setpriorityclass
+	h, err := windows.OpenProcess(windows.PROCESS_SET_INFORMATION, false, uint32(p.Pid))
+	if err != nil {
+		return err
+	}
+
+	// Attempt to modify the priority class of the child process
+	return windows.SetPriorityClass(h, windows.BELOW_NORMAL_PRIORITY_CLASS)
+}

--- a/pkg/tasks/transcode_video.go
+++ b/pkg/tasks/transcode_video.go
@@ -63,6 +63,7 @@ func (t *TranscodeVideo) Do(ctx context.Context, inputFilename string) (string, 
 		OutputFilename:    outputFilename,
 		SubtitleLanguages: opts.SubtitleLanguages,
 		SubtitleOptions:   subtitleOpts,
+		UseLowerPriority:  true,
 		VideoOptions:      videoOpts,
 	}
 

--- a/pkg/tasks/transcode_video.go
+++ b/pkg/tasks/transcode_video.go
@@ -11,9 +11,10 @@ import (
 )
 
 type TranscodeVideo struct {
-	Logger  *zap.SugaredLogger
-	Options TranscodeVideoOptions
-	WorkDir string
+	Logger           *zap.SugaredLogger
+	Options          TranscodeVideoOptions
+	UseLowerPriority bool
+	WorkDir          string
 }
 
 type TranscodeVideoOptions struct {
@@ -63,7 +64,7 @@ func (t *TranscodeVideo) Do(ctx context.Context, inputFilename string) (string, 
 		OutputFilename:    outputFilename,
 		SubtitleLanguages: opts.SubtitleLanguages,
 		SubtitleOptions:   subtitleOpts,
-		UseLowerPriority:  true,
+		UseLowerPriority:  t.UseLowerPriority,
 		VideoOptions:      videoOpts,
 	}
 


### PR DESCRIPTION
- When --low-priority is set, subprocesses (ffmpeg/mkvmerge/etc) run at a lower than normal process priority

Closes #6 